### PR TITLE
chore: adjust config for easier mocking

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,9 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   setupFiles: ['<rootDir>/jest.polyfills.js'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
   testEnvironment: 'jsdom',
   transform: {
     '^.+\\.(t|j)sx?$': '@swc/jest',


### PR DESCRIPTION

This allows mocking with the @ path eg.

```
jest.mock('@/your path here', () => ())